### PR TITLE
Primitive Highlighting 

### DIFF
--- a/data_store/sparseUtilizationList.py
+++ b/data_store/sparseUtilizationList.py
@@ -151,17 +151,21 @@ class SparseUtilizationList():
                 while location_struct_index[location] < location_struct_length[location]:
                     locStruct = self.locationDict[location][location_struct_index[location]]
                     # since its sorted per location, all end indexes are from the same interval of previous enter index
-                    startIndex = self.locationDict[location][location_struct_index[location]-1]['index']
-                    if locStruct['primitive'] == primitive and locStruct['counter'] == 0 and startIndex < criticalPts:
-                        intervalChunkStart = max(preCriticalPts, startIndex)
-                        intervalChunkEnd = min(criticalPts, locStruct['index'])
-                        currentUtil = intervalChunkEnd - intervalChunkStart  # it should cover left/right/full overlap cases
-                        duration = locStruct['index'] - startIndex
-                        durationIndex = int((duration - durationBegin) // rangePerDurationBin)
-                        primitiveCountPerBin[i, durationIndex] = primitiveCountPerBin[i, durationIndex] + float(currentUtil)
-                        if primitiveCountPerBin[i, durationIndex] < 0:
-                            print("Error: negative Util found " + str(primitiveCountPerBin[i, durationIndex]))
-                            return []
+                    if location_struct_index[location] > 0:
+                        startIndex = self.locationDict[location][location_struct_index[location]-1]['index']
+                    else:
+                        startIndex = 0
+                    if locStruct['primitive'] == primitive and locStruct['counter'] == 0:
+                        if startIndex < criticalPts:
+                            intervalChunkStart = max(preCriticalPts, startIndex)
+                            intervalChunkEnd = min(criticalPts, locStruct['index'])
+                            currentUtil = intervalChunkEnd - intervalChunkStart  # it should cover left/right/full overlap cases
+                            duration = locStruct['index'] - startIndex
+                            durationIndex = int((duration - durationBegin) // rangePerDurationBin)
+                            primitiveCountPerBin[i, durationIndex] = primitiveCountPerBin[i, durationIndex] + float(currentUtil)
+                            if primitiveCountPerBin[i, durationIndex] < 0:
+                                print("Error: negative Util found " + str(primitiveCountPerBin[i, durationIndex]))
+                                return []
                         if locStruct['index'] > criticalPts:  # check this explicitly, you dont wanna increase the index number
                             break
                     location_struct_index[location] = location_struct_index[location] + 1

--- a/data_store/sparseUtilizationList.py
+++ b/data_store/sparseUtilizationList.py
@@ -126,12 +126,19 @@ class SparseUtilizationList():
         return prettyHistogram
 
     # Calculates utilization for each primitive and returns util per duration
-    def calcUtilizationForPrimitive(self, bins=100, begin=None, end=None, primitive=None):
+    def calcUtilizationForPrimitive(self, bins=100,
+                                    begin=None,
+                                    end=None,
+                                    primitive=None,
+                                    durationBegin=None,
+                                    durationEnd=None,
+                                    durationBins=100):
         primitiveCountPerBin = []
         if primitive is None:
             return primitiveCountPerBin
 
         rangePerBin = (end-begin)/bins
+        rangePerDurationBin = (durationEnd-durationBegin)/durationBins
         location_struct_index = dict()
         location_struct_length = dict()
         preCriticalPts = begin
@@ -154,9 +161,10 @@ class SparseUtilizationList():
                         intervalChunkEnd = min(criticalPts, locStruct['index'])
                         currentUtil = intervalChunkEnd - intervalChunkStart  # it should cover left/right/full overlap cases
                         duration = locStruct['index'] - startIndex
-                        if duration not in utilPerDuration:
-                            utilPerDuration[duration] = 0
-                        utilPerDuration[duration] = utilPerDuration[duration] + currentUtil
+                        durationIndex = int((duration - durationBegin) // rangePerDurationBin)
+                        if durationIndex not in utilPerDuration:
+                            utilPerDuration[durationIndex] = 0
+                        utilPerDuration[durationIndex] = utilPerDuration[durationIndex] + currentUtil
                         if locStruct['index'] > criticalPts:  # check this explicitly, you dont wanna increase the index number
                             break
                     location_struct_index[location] = location_struct_index[location] + 1

--- a/data_store/sparseUtilizationList.py
+++ b/data_store/sparseUtilizationList.py
@@ -79,7 +79,7 @@ class SparseUtilizationList():
     def calcIntervalHistogram(self, bins=100, begin=None, end=None):
         return self.calcUtilizationForLocation(bins, begin, end, 1, False)
 
-    # Calulates utilization for one location in a Gantt chart
+    # Calculates utilization for one location in a Gantt chart
     # Location designates a particular CPU or Thread and denotes the y-axis on the Gantt Chart
     def calcUtilizationForLocation(self, bins=100, begin=None, end=None, Location=None, isInterval=True):
         rangePerBin = (end-begin)/bins
@@ -125,6 +125,46 @@ class SparseUtilizationList():
             prettyHistogram.append(histogram[i]['integral'])
         return prettyHistogram
 
+    # Calculates utilization for each primitive and returns util per duration
+    def calcUtilizationForPrimitive(self, bins=100, begin=None, end=None, primitive=None):
+        primitiveCountPerBin = []
+        if primitive is None:
+            return primitiveCountPerBin
+
+        rangePerBin = (end-begin)/bins
+        location_struct_index = dict()
+        location_struct_length = dict()
+        preCriticalPts = begin
+        for i in range(1, bins):
+            criticalPts = (i * rangePerBin) + begin
+            utilPerDuration = dict()
+
+            for location in self.locationDict:
+                if location not in location_struct_index:
+                    location_struct_index[location] = 0
+                if location not in location_struct_length:
+                    location_struct_length[location] = len(self.locationDict[location])
+
+                while location_struct_index[location] < location_struct_length[location]:
+                    locStruct = self.locationDict[location][location_struct_index[location]]
+                    # since its sorted per location, all end indexes are from the same interval of previous enter index
+                    if locStruct['primitive'] == primitive and locStruct['counter'] == 0:
+                        startIndex = self.locationDict[location][location_struct_index[location]-1]['index']
+                        intervalChunkStart = max(preCriticalPts, startIndex)
+                        intervalChunkEnd = min(criticalPts, locStruct['index'])
+                        currentUtil = intervalChunkEnd - intervalChunkStart  # it should cover left/right/full overlap cases
+                        duration = locStruct['index'] - startIndex
+                        if duration not in utilPerDuration:
+                            utilPerDuration[duration] = 0
+                        utilPerDuration[duration] = utilPerDuration[duration] + currentUtil
+                        if locStruct['index'] > criticalPts:  # check this explicitly, you dont wanna increase the index number
+                            break
+                    location_struct_index[location] = location_struct_index[location] + 1
+
+            primitiveCountPerBin.append(utilPerDuration)
+            preCriticalPts = criticalPts
+        return primitiveCountPerBin
+
 
 # In charge of loading interval data into our integral list
 # I have no idea how we want to load interval data :/
@@ -165,8 +205,9 @@ async def loadSUL(label, db, log=logToConsole):
     for loc in db[label]['intervalIndexes']['locations']:
         counter = 0
         for i in db[label]['intervalIndexes']['locations'][loc].iterOverlap(begin, end):
-            sul['intervals'].setIntervalAtLocation({'index': int(i.begin), 'counter': 1, 'util': 0}, loc)
-            sul['intervals'].setIntervalAtLocation({'index': int(i.end), 'counter': -1, 'util': 0}, loc)
+            primitive_name = db[label]['intervals'][i.data]['Primitive']
+            sul['intervals'].setIntervalAtLocation({'index': int(i.begin), 'counter': 1, 'util': 0, 'primitive': primitive_name}, loc)
+            sul['intervals'].setIntervalAtLocation({'index': int(i.end), 'counter': -1, 'util': 0, 'primitive': primitive_name}, loc)
             updateSULForInterval(db[label]['intervals'][i.data]['enter'], loc)
             updateSULForInterval(db[label]['intervals'][i.data]['leave'], loc)
             updateIntervalDuration(db[label]['intervals'][i.data])

--- a/serve.py
+++ b/serve.py
@@ -712,12 +712,27 @@ def getIntervalDuration(label: str, bins: int = 100, begin: int = None, end: int
     ret['metadata'] = {'begin': begin, 'end': end, 'bins': bins}
     return ret
 
+
 @app.get('/datasets/{label}/getPrimitiveList')
 def getPrimitiveList(label: str):
     checkDatasetExistence(label)
     ret = []
     for primitive in db[label]['sparseUtilizationList']['intervalDuration']:
         ret.append(primitive)
+    return ret
+
+
+@app.get('/datasets/{label}/getUtilizationForPrimitive')
+def getDrawValues(label: str, bins: int = 100, begin: int = None, end: int = None, primitive: str = None):
+    checkDatasetExistence(label)
+    checkDatasetHasIntervals(label)
+    if begin is None:
+        begin = db[label]['meta']['intervalDomain'][0]
+    if end is None:
+        end = db[label]['meta']['intervalDomain'][1]
+
+    ret = {'data': db[label]['sparseUtilizationList']['intervals'].calcUtilizationForPrimitive(bins, begin, end, primitive),
+           'metadata': {'begin': begin, 'end': end, 'bins': bins}}
     return ret
 
 #####################

--- a/serve.py
+++ b/serve.py
@@ -703,7 +703,7 @@ def getIntervalDuration(label: str, bins: int = 100, begin: int = None, end: int
     if begin is None:
         begin = int(db[label]['meta']['intervalDurationDomain'][primitive][0])
     if end is None:
-        end = db[label]['meta']['intervalDurationDomain'][primitive][1]
+        end = int(db[label]['meta']['intervalDurationDomain'][primitive][1])
 
     ret = {}
     if primitive is None:
@@ -723,7 +723,7 @@ def getPrimitiveList(label: str):
 
 
 @app.get('/datasets/{label}/getUtilizationForPrimitive')
-def getDrawValues(label: str, bins: int = 100, begin: int = None, end: int = None, primitive: str = None):
+def getDrawValues(label: str, bins: int = 100, begin: int = None, end: int = None, primitive: str = None, duration_bins: int = 100):
     checkDatasetExistence(label)
     checkDatasetHasIntervals(label)
     if begin is None:
@@ -731,7 +731,15 @@ def getDrawValues(label: str, bins: int = 100, begin: int = None, end: int = Non
     if end is None:
         end = db[label]['meta']['intervalDomain'][1]
 
-    ret = {'data': db[label]['sparseUtilizationList']['intervals'].calcUtilizationForPrimitive(bins, begin, end, primitive),
+    durationBegin = int(db[label]['meta']['intervalDurationDomain'][primitive][0])
+    durationEnd = int(db[label]['meta']['intervalDurationDomain'][primitive][1])
+    ret = {'data': db[label]['sparseUtilizationList']['intervals'].calcUtilizationForPrimitive(bins,
+                                                                                               begin,
+                                                                                               end,
+                                                                                               primitive,
+                                                                                               durationBegin,
+                                                                                               durationEnd,
+                                                                                               duration_bins),
            'metadata': {'begin': begin, 'end': end, 'bins': bins}}
     return ret
 

--- a/serve.py
+++ b/serve.py
@@ -723,7 +723,7 @@ def getPrimitiveList(label: str):
 
 
 @app.get('/datasets/{label}/getUtilizationForPrimitive')
-def getDrawValues(label: str, bins: int = 100, begin: int = None, end: int = None, primitive: str = None, duration_bins: int = 100):
+def getUtilizationForPrimitive(label: str, bins: int = 100, begin: int = None, end: int = None, primitive: str = None, duration_bins: int = 100):
     checkDatasetExistence(label)
     checkDatasetHasIntervals(label)
     if begin is None:

--- a/static/models/LinkedState.js
+++ b/static/models/LinkedState.js
@@ -370,15 +370,18 @@ class LinkedState extends Model {
       }
 
       // do the precalculation here
-      this.primitiveHistogram[currentPrimitive].aux = new Array(this.histogramResolution).fill(new Array(durationBins).fill(0));
-      for(let i=0; i<durationBins; i++){
-        this.primitiveHistogram[currentPrimitive].aux[0][i] = this.primitiveHistogram[currentPrimitive].data[0][i];
+      this.primitiveHistogram[currentPrimitive].aux = new Array(this.histogramResolution);
+      for(let i=0; i<this.histogramResolution; i++){
+        this.primitiveHistogram[currentPrimitive].aux[i] = new Array(durationBins);
       }
       for(let i=0; i<this.histogramResolution; i++){
-        for(let j=1; j<durationBins; j++){
+        for(let j=0; j<durationBins; j++){
+          var preValue = 0;
+          if(j>0) {
+            preValue = this.primitiveHistogram[currentPrimitive].aux[i][j-1];
+          }
           this.primitiveHistogram[currentPrimitive].aux[i][j] =
-              this.primitiveHistogram[currentPrimitive].aux[i][j]
-              + this.primitiveHistogram[currentPrimitive].aux[i][j-1];
+              this.primitiveHistogram[currentPrimitive].data[i][j] + preValue;
         }
       }
 
@@ -390,7 +393,10 @@ class LinkedState extends Model {
     const durationBins = this.histogramResolution;
     const rangePerDurationBin = (this.intervalHistogramEndLimit-this.intervalHistogramBeginLimit)/durationBins;
     const beginIndex = ((begin - this.intervalHistogramBeginLimit) / rangePerDurationBin) | 0;
-    const endIndex = (((end - this.intervalHistogramBeginLimit) / rangePerDurationBin) | 0) - 1;
+    let endIndex = (((end - this.intervalHistogramBeginLimit) / rangePerDurationBin) | 0);
+    if(endIndex > 0) {
+      endIndex = endIndex - 1;
+    }
     var ret = new Array(this.histogramResolution).fill(0);
     const rangePerBin = (this.primitiveHistogram[currentPrimitive].metadata.end - this.primitiveHistogram[currentPrimitive].metadata.begin)
                     / this.primitiveHistogram[currentPrimitive].metadata.bins;

--- a/static/models/LinkedState.js
+++ b/static/models/LinkedState.js
@@ -355,6 +355,9 @@ class LinkedState extends Model {
     }, 100);
   }
   fetchPrimitiveHistogramData(){
+    if(!this.selectedPrimitiveHistogram) {
+      return;
+    }
     window.clearTimeout(this._primitiveHistogramTimeout);
     this._primitiveHistogramTimeout = window.setTimeout(async () => {
       const currentPrimitive = this.selectedPrimitiveHistogram;
@@ -390,6 +393,9 @@ class LinkedState extends Model {
   }
   getPrimitiveHistogramForDuration(begin, end){
     const currentPrimitive = this.selectedPrimitiveHistogram;
+    if(!this.primitiveHistogram || !(currentPrimitive in this.primitiveHistogram)){
+      return;
+    }
     const durationBins = this.histogramResolution;
     const rangePerDurationBin = (this.intervalHistogramEndLimit-this.intervalHistogramBeginLimit)/durationBins;
     const beginIndex = ((begin - this.intervalHistogramBeginLimit) / rangePerDurationBin) | 0;
@@ -424,6 +430,7 @@ class LinkedState extends Model {
               this.intervalHistogram[primitive] = data;
               this.intervalHistogramWindow[primitive] = [this.intervalHistogramBeginLimit, this.intervalHistogramEndLimit];
               this.trigger('intervalHistogramUpdated');
+              this.fetchPrimitiveHistogramData();
             })
             .catch(err => {
               err.text.then( errorMessage => {

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -126,14 +126,14 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
       // Make sure we render eventually
       this.render();
     });
-    // this.linkedState.on('newIntervalHistogramWindow', () => {
-    //     window.clearTimeout(this.intervalHistogramFetchTimeout);
-    //     this.intervalHistogramFetchTimeout = window.setTimeout(async () => {
-    //         this.fetchAndDrawHighlightedBars(this.linkedState.intervalHistogramBegin,
-    //             this.linkedState.intervalHistogramEnd,
-    //             this.IntervalListMode.duration);
-    //     }, 300);
-    // });
+    this.linkedState.on('newIntervalHistogramWindow', () => {
+        window.clearTimeout(this.intervalHistogramFetchTimeout);
+        this.intervalHistogramFetchTimeout = window.setTimeout(async () => {
+            this.fetchAndDrawHighlightedBars(this.linkedState.intervalHistogramBegin,
+                this.linkedState.intervalHistogramEnd,
+                this.IntervalListMode.duration);
+        }, 300);
+    });
 
     this.currentClickState = this.ClickState.background;
     var __self = this;

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -202,7 +202,8 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
               })
               .then((data) => {
                   if(data.length > 0) {
-                      data[0].metrics = undefined;
+                      data[0].enter.metrics = undefined;
+                      data[0].leave.metrics = undefined;
                       data[0].intervalId = undefined;
                       data[0].lastParentInterval = undefined;
                       var dr = __self.canvasElement.node().getBoundingClientRect();
@@ -459,6 +460,9 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
       }
   }
   fetchAndDrawHighlightedBars(x, y, mode) {
+      if((this.linkedState.end - this.linkedState.begin) > 20000000) {
+          return;
+      }
       if(this.intervalRenderingBegins(x, y, mode) === true) return;
       this.drawHighlightedBars(this.IntervalListMode.all);
       this.fetchIntervalList(x, y, mode);

--- a/static/views/GanttView/GanttView.js
+++ b/static/views/GanttView/GanttView.js
@@ -126,14 +126,14 @@ class GanttView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenLayoutV
       // Make sure we render eventually
       this.render();
     });
-    this.linkedState.on('newIntervalHistogramWindow', () => {
-        window.clearTimeout(this.intervalHistogramFetchTimeout);
-        this.intervalHistogramFetchTimeout = window.setTimeout(async () => {
-            this.fetchAndDrawHighlightedBars(this.linkedState.intervalHistogramBegin,
-                this.linkedState.intervalHistogramEnd,
-                this.IntervalListMode.duration);
-        }, 300);
-    });
+    // this.linkedState.on('newIntervalHistogramWindow', () => {
+    //     window.clearTimeout(this.intervalHistogramFetchTimeout);
+    //     this.intervalHistogramFetchTimeout = window.setTimeout(async () => {
+    //         this.fetchAndDrawHighlightedBars(this.linkedState.intervalHistogramBegin,
+    //             this.linkedState.intervalHistogramEnd,
+    //             this.IntervalListMode.duration);
+    //     }, 300);
+    // });
 
     this.currentClickState = this.ClickState.background;
     var __self = this;

--- a/static/views/IntervalHistogramView/IntervalHistogramView.js
+++ b/static/views/IntervalHistogramView/IntervalHistogramView.js
@@ -91,31 +91,6 @@ class IntervalHistogramView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(G
     var __self = this;
     // mouse events
     this.canvasElement = this.content.select('.histogram-plot');
-        // .on('click', function() {
-        //   console.log("clicked");
-        // })
-        // .on('mouseleave', function () {
-        //   __self.isMouseInside = false;
-        //   __self.clearAllTimer();
-        // })
-        // .on('mouseenter',function () {
-        //   __self.isMouseInside = true;
-        // })
-        // .on('mousemove', function() {
-        //   __self.clearAllTimer();
-        //   if(__self.currentClickState === __self.ClickState.background || __self.currentClickState === __self.ClickState.hover) {
-        //     var dm = d3.mouse(__self.content.select('.histogram-container').node());
-        //     this._mouseHoverTimeout = window.setTimeout(async () => {
-        //       if(__self.isMouseInside === true) {
-        //         __self.showDetailsTooltip(dm[0], dm[1]);
-        //       }
-        //     }, 100);
-        //   }
-        // })
-        // .on('dblclick', function() {
-        //   __self.clearAllTimer();
-        //   console.log("dbl clicked");
-        // });
     this.canvasContext = this.canvasElement.node().getContext('2d');
     this.linkedState.fetchIntervalHistogram(this.curPrimitive);
     this.linkedState.on('intervalHistogramUpdated', () => {
@@ -174,7 +149,6 @@ class IntervalHistogramView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(G
   }
   draw () {
     super.draw();
-    // console.log('draw called ' + this.curMetric);
     if (this.isHidden) {
       return;
     } else if (this.isEmpty) {

--- a/static/views/UtilizationView/UtilizationView.js
+++ b/static/views/UtilizationView/UtilizationView.js
@@ -61,9 +61,9 @@ class UtilizationView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenL
       // Full render whenever we have new histograms
       this.render();
     });
-    this.linkedState.on('intervalHistogramUpdated', () => {
-      this.linkedState.fetchPrimitiveHistogramData();
-    });
+    // this.linkedState.on('intervalHistogramUpdated', () => {
+      // this.linkedState.fetchPrimitiveHistogramData();
+    // });
     this.linkedState.on('primitiveHistogramUpdated', () => {
       const primitiveData = this.linkedState.getPrimitiveHistogramForDuration(this.linkedState.intervalHistogramBeginLimit,
           this.linkedState.intervalHistogramEndLimit);
@@ -76,6 +76,8 @@ class UtilizationView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenL
     });
     // Grab new histograms whenever the view is resized
     this.container.on('resize', () => {
+      const selectedPrimitive = this.content.select('.selectedPrimitive');
+      selectedPrimitive.style('display', 'none');
       const nPixels = Math.floor(this.getChartBounds().width);
       this.linkedState.setHistogramResolution(nPixels);
     });
@@ -90,30 +92,14 @@ class UtilizationView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenL
     } else if (data.error) {
       this.emptyStateDiv.html('<p>Error communicating with the server</p>');
     } else {
-      // console.log(data);
       // Set / update the scales
       this.xScale.domain(data.domain);
       this.yScale.domain([0, data.maxCount]);
 
       // Update the axis
       this.drawAxes();
-
       // Update the overview paths
       this.drawPaths(this.content.select('.overview'), data.histogram);
-
-      // // Update the overview paths
-      // this.drawPrimitivePaths(this.content.select('.selectedPrimitive'), data.histogram);
-
-      // // Update the currently selected primitive paths
-      const selectedPrimitive = this.content.select('.selectedPrimitive');
-      selectedPrimitive.style('display', null);
-      // if (data.primitiveHistogram) {
-        selectedPrimitive.select('.area')
-          .style('fill', this.linkedState.selectionColor);
-        selectedPrimitive.select('.outline')
-          .style('stroke', this.linkedState.selectionColor);
-      // }
-
       // Update the brush
       this.drawBrush();
     }
@@ -157,6 +143,16 @@ class UtilizationView extends CursoredViewMixin(SvgViewMixin(LinkedMixin(GoldenL
         .attr('d', areaPathGenerator);
   }
   drawPrimitivePaths (container, histogram) {
+    if(histogram) {
+      container.style('display', null);
+      container.select('.area')
+          .style('fill', this.linkedState.selectionColor);
+      container.select('.outline')
+          .style('stroke', this.linkedState.selectionColor);
+    } else {
+      container.style('display', 'none');
+      return;
+    }
     const rat = 1;
     const outlinePathGenerator = d3.line()
         .x((d, i) => this.xScale(this.linkedState.getTimeStampFromBin(i, histogram.metadata)))


### PR DESCRIPTION
### Utilization calculation for each primitive

- Did one sweep over all the intervals in the visible window 
(for the utilization view - it is the whole execution run, but it will work for any subsection of the execution run also)
For each interval with `start_index` and `end_index`, the main logic to update the primitive utilization per bin as follows:

```
intervalChunkStart = max(previous_bin_index, start_index)
intervalChunkEnd = min(current_bin_index, end_index])
current_bin_utilization = intervalChunkEnd - intervalChunkStart
```

- Newly added API: `getUtilizationForPrimitive`
- Wrapper for the API in the linkedState: `fetchPrimitiveHistogramData`
- Cached values for the primitive utilization can be fetched from the linkedState function:  `getPrimitiveHistogramForDuration` 
(set the current primitive name in the `linkedState.selectedPrimitiveHistogram`)