### PR TITLE
Adding dynamic color highlighting system in traveler

### DIFF
--- a/static/models/states/LinkedState.js
+++ b/static/models/states/LinkedState.js
@@ -3,6 +3,7 @@
 import PrimitiveSelection from '../selections/PrimitiveSelection.js';
 
 import RenameModal from '../../views/RenameModal/RenameModal.js';
+import ChangeColorModal from '../../views/ChangeColorModal/ChangeColorModal.js';
 import TreeView from "../../views/TreeView/TreeView.js";
 import DependencyTreeView from "../../views/DependencyTreeView/DependencyTreeView.js";
 import TaskDependencySelection from "../selections/TaskDependencySelection.js";
@@ -224,6 +225,12 @@ class LinkedState extends uki.utils.IntrospectableMixin(uki.Model) {
         label: 'Rename / Manage Tags...',
         onclick: () => {
           uki.ui.showModal(new RenameModal({ dataset: this }));
+        }
+      },  // Changes the dataset color according to user's choice
+      {
+        label: 'Change Dataset Color', 
+        onclick: () => {
+          uki.ui.showModal(new ChangeColorModal({ dataset: this }));
         }
       },
       {

--- a/static/views/ChangeColorModal/ChangeColorModal.js
+++ b/static/views/ChangeColorModal/ChangeColorModal.js
@@ -1,0 +1,46 @@
+/* globals uki */
+/* Change Color Modal will prompt the user to select the selection color for the selected dataset. */
+class ChangeColorModal extends uki.ui.ModalView {
+  constructor (options = {}) {
+    options.resources = options.resources || [];
+    options.resources.push(...[
+      { type: 'text', url: 'views/ChangeColorModal/content.html', name: 'content' },
+      { type: 'less', url: 'views/ChangeColorModal/style.less' }
+    ]);
+
+    options.content = null;
+    super(options);
+
+    this.dataset = options.dataset;
+  }
+
+  async setup () {
+    await super.setup(...arguments);
+
+    this.d3el.classed('ChangeColorModal', true);
+
+    this.modalContentEl.html(this.getNamedResource('content'))
+      .select('#datasetLabel')
+      .property('value', this.dataset.info.label)
+      .on('change keyup', () => { this.render(); });
+  }
+
+  async confirmAction () {
+    const newLabel = this.modalContentEl
+      .select('#datasetLabel').property('value');
+    await this.dataset
+      .setLabelAndTags(newLabel, this._tagsToAdd, this._tagsToRemove);
+  }
+
+  validateForm () {
+    const newLabel = this.modalContentEl.select('#datasetLabel')
+      .property('value');
+    return newLabel.length === 0 ? ['#datasetLabel'] : null;
+  }
+
+  displayValidationErrors () {
+    this.modalContentEl.select('#datasetLabel')
+      .classed('error', true);
+  }
+}
+export default ChangeColorModal;

--- a/static/views/ChangeColorModal/content.html
+++ b/static/views/ChangeColorModal/content.html
@@ -1,0 +1,11 @@
+<label for="datasetLabel">Dataset</label>
+<input id="datasetLabel"/>
+
+<hr/>
+<label> Choose the Dataset color </label>
+<hr/>
+<label for="colorpicker">Selection Color:</label>
+<input type="color" id="colorpicker" value="#e6ab02">
+
+
+

--- a/static/views/ChangeColorModal/style.less
+++ b/static/views/ChangeColorModal/style.less
@@ -1,0 +1,24 @@
+/*style section of change color modal*/
+.ChangeColorModal {
+  label, input {
+    display: inline-block;
+    margin-right: 1em;
+  }
+  .addTag.button {
+    vertical-align: top;
+  }
+  hr {
+    margin-top: 0;
+    margin-bottom: 1em;
+  }
+  .tagList {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    align-items: flex-start;
+    align-content: flex-start;
+    max-width: 30em;
+    height: 7em;
+    overflow-y: auto;
+  }
+}


### PR DESCRIPTION
"Change Dataset color" option is added to datasets context menu. With this feature, a user can change the dataset selection color and main menu color to be distinguishable from other datasets. Currently, I have only completed the front-end part. The back-end part is still in progress. The screenshots of changes done till now are displayed below:

![Screenshot from 2022-07-18 23-19-46](https://user-images.githubusercontent.com/42024284/179615045-bb7325b4-529c-4e72-a434-3dd83426184e.png)
![Screenshot from 2022-07-18 23-19-26](https://user-images.githubusercontent.com/42024284/179615268-76517211-09dd-4378-8bfe-b370b2be1fa2.png)
